### PR TITLE
migrates base image to alpine and tini

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,42 +1,8 @@
-FROM phusion/baseimage:latest
+FROM node:8.9-alpine
 
 ENV HOME /root
 WORKDIR /root
 
-RUN set -ex \
-  && for key in \
-    9554F04D7259F04124DE6B476D5A82AC7E37093B \
-    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
-    0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
-    FD3A5288F042B6850C66B31F09FE44734EB7990E \
-    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
-    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
-    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
-    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
-  ; do \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
-  done
-
-ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 8.9.1
-
-RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
-  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
-  && gpg --verify SHASUMS256.txt.asc \
-  && grep " node-v$NODE_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - \
-  && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
-  && rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc
-
-
-RUN apt-get update \
-&& apt-get upgrade -y --no-install-recommends \
-&& apt-get install -y software-properties-common \
-&& apt-get install -y curl git htop unzip vim wget netcat
-
-RUN npm i -g yarn
-
-# Increase limits
-RUN touch /etc/security/limits.d/my.conf \
-&& echo '* hard nofile 16384' >> /etc/security/limits.d/my.conf \
-&& echo '* soft nofile 16384' >> /etc/security/limits.d/my.conf \
-&& apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+# install tini to properly handle zombie reaping & signal comm
+RUN apk add --no-cache tini
+ENTRYPOINT ["/sbin/tini", "--"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM node:8.9-alpine
 ENV HOME /root
 WORKDIR /root
 
+
 # install tini to properly handle zombie reaping & signal comm
-RUN apk add --no-cache tini
+RUN apk add --update --no-cache bash tini
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ WORKDIR /root
 
 
 # install tini to properly handle zombie reaping & signal comm
-RUN apk add --update --no-cache bash tini
+RUN apk add --update --no-cache bash curl tini
 ENTRYPOINT ["/sbin/tini", "--"]


### PR DESCRIPTION
* inspected official node Dockerfile, decided to put trust into official node images
* migrated image to alpine
* added tinit to handle init

I pushed branch `8.9-alpine` to have the image available.
This PR will set master to `8.9-alpine`