### PR TITLE
Continuous updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script:
 - docker build -t stocard/node:$TRAVIS_COMMIT .
 - docker tag stocard/node:$TRAVIS_COMMIT stocard/node:$TRAVIS_BRANCH
 after_success:
-- docker login -u="$DOCKER_USERNAME" -p="DOCKER_PASSWORD" && docker push stocard/node:$TRAVIS_COMMIT && docker push stocard/node:$TRAVIS_BRANCH && docker logout
+- docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" && docker push stocard/node:$TRAVIS_COMMIT && docker push stocard/node:$TRAVIS_BRANCH && docker logout
 env:
   global:
   - secure: qiWFg23Mmpx+1y4s3SSH5/BmhTSTG2kABgFB52eu3mXqd/eFoJy33zSN/T5+o7JjvEJ/Up4hxfvLCu4bt6n/t8QHkeey4V1ZCp7AI/zpNelK2y1QkBdJUBhORWjUxYGEW0cEmh/NdV0XN58/uXTG8v9rae8JA642+zYXdjUewsKLx/rYrqOwj7ugK/OfPW/9LBSnj/nIXOJdHp9EHnMc5GbXTOqETuBsNdylD567QziEVncJdJYlYw8Aku03aIZ4Brxyr6s7j5lzoN4YM2aW/Tyaybb6+ph7GMZsJd6Fe5u0NrZ8JgV/j4bPfnpaToOUO+DKF8QeaEaff6eboNHmbWwQm5OHz9rGy2zam6qE1PmKs/FEhNa+i2Kn9DD0o88arUVLkk6p8wpBe4TtoYqUd22sBPsJherI1kvQdKcEhhc2X56lqfK1HrNabZaYp7UOoRibdPRyAkcgPR18Y89GEf29TnD9vGfWWd4m+1iCYiaZmxwO1dJ6mabkdc99nkLfH8bH9HM+0v5ZanB91iA7mZcZ6GarcGh4AsY8K8eJEcZWehxk09GS3Q75J9kb7oVnQzquPhYa1DVs0bY/crYcltlgAJnCmlgWuBxYChu1cx2H4JdZFiIR1RpXW5D2NnCaLpueNp5FanFF1CXbgQpwMasGCVIWlmBx27x+wJPwOC4=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
 sudo: required
+env:
+  - NODE=8
+  - NODE=8.11
+  - NODE=10
 services:
 - docker
 script:
-- docker build -t stocard/node:$TRAVIS_COMMIT .
-- docker tag stocard/node:$TRAVIS_COMMIT stocard/node:$TRAVIS_BRANCH
-after_success:
-- docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" && docker push stocard/node:$TRAVIS_COMMIT && docker push stocard/node:$TRAVIS_BRANCH && docker logout
+  - echo $NODE
+# - docker build -t stocard/node:$TRAVIS_COMMIT .
+# - docker tag stocard/node:$TRAVIS_COMMIT stocard/node:$TRAVIS_BRANCH
+# after_success:
+# - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" && docker push stocard/node:$TRAVIS_COMMIT && docker push stocard/node:$TRAVIS_BRANCH && docker logout
 env:
   global:
   - secure: qiWFg23Mmpx+1y4s3SSH5/BmhTSTG2kABgFB52eu3mXqd/eFoJy33zSN/T5+o7JjvEJ/Up4hxfvLCu4bt6n/t8QHkeey4V1ZCp7AI/zpNelK2y1QkBdJUBhORWjUxYGEW0cEmh/NdV0XN58/uXTG8v9rae8JA642+zYXdjUewsKLx/rYrqOwj7ugK/OfPW/9LBSnj/nIXOJdHp9EHnMc5GbXTOqETuBsNdylD567QziEVncJdJYlYw8Aku03aIZ4Brxyr6s7j5lzoN4YM2aW/Tyaybb6+ph7GMZsJd6Fe5u0NrZ8JgV/j4bPfnpaToOUO+DKF8QeaEaff6eboNHmbWwQm5OHz9rGy2zam6qE1PmKs/FEhNa+i2Kn9DD0o88arUVLkk6p8wpBe4TtoYqUd22sBPsJherI1kvQdKcEhhc2X56lqfK1HrNabZaYp7UOoRibdPRyAkcgPR18Y89GEf29TnD9vGfWWd4m+1iCYiaZmxwO1dJ6mabkdc99nkLfH8bH9HM+0v5ZanB91iA7mZcZ6GarcGh4AsY8K8eJEcZWehxk09GS3Q75J9kb7oVnQzquPhYa1DVs0bY/crYcltlgAJnCmlgWuBxYChu1cx2H4JdZFiIR1RpXW5D2NnCaLpueNp5FanFF1CXbgQpwMasGCVIWlmBx27x+wJPwOC4=

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ sudo: required
 
 matrix:
   include:
-    env: NODE=8
-    env: NODE=8.11
-    env: NODE=10
+    - env: NODE=8
+    - env: NODE=10
+    - env: NODE=8.11
 
 services:
-- docker
+  - docker
 script:
   - echo "$NODE"
 # - docker build -t stocard/node:$TRAVIS_COMMIT .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 sudo: required
-env:
-  matrix:
-    - NODE=8
-    - NODE=8.11
-    - NODE=10
+
+matrix:
+  include:
+    env: NODE=8
+    env: NODE=8.11
+    env: NODE=10
+
 services:
 - docker
 script:
-  - echo $NODE
+  - echo "$NODE"
 # - docker build -t stocard/node:$TRAVIS_COMMIT .
 # - docker tag stocard/node:$TRAVIS_COMMIT stocard/node:$TRAVIS_BRANCH
 # after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-
+language: generic
 matrix:
   include:
     - env: NODE=8
@@ -9,11 +9,10 @@ matrix:
 services:
   - docker
 script:
-  - echo "$NODE"
-# - docker build -t stocard/node:$TRAVIS_COMMIT .
-# - docker tag stocard/node:$TRAVIS_COMMIT stocard/node:$TRAVIS_BRANCH
-# after_success:
-# - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" && docker push stocard/node:$TRAVIS_COMMIT && docker push stocard/node:$TRAVIS_BRANCH && docker logout
+- sed -i "s/{VERSION}/${NODE}/g" ./Dockerfile
+- docker build -t stocard/node:$NODE .
+after_success:
+- docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" && docker push stocard/node:$NODE && docker logout
 env:
   global:
   - secure: qiWFg23Mmpx+1y4s3SSH5/BmhTSTG2kABgFB52eu3mXqd/eFoJy33zSN/T5+o7JjvEJ/Up4hxfvLCu4bt6n/t8QHkeey4V1ZCp7AI/zpNelK2y1QkBdJUBhORWjUxYGEW0cEmh/NdV0XN58/uXTG8v9rae8JA642+zYXdjUewsKLx/rYrqOwj7ugK/OfPW/9LBSnj/nIXOJdHp9EHnMc5GbXTOqETuBsNdylD567QziEVncJdJYlYw8Aku03aIZ4Brxyr6s7j5lzoN4YM2aW/Tyaybb6+ph7GMZsJd6Fe5u0NrZ8JgV/j4bPfnpaToOUO+DKF8QeaEaff6eboNHmbWwQm5OHz9rGy2zam6qE1PmKs/FEhNa+i2Kn9DD0o88arUVLkk6p8wpBe4TtoYqUd22sBPsJherI1kvQdKcEhhc2X56lqfK1HrNabZaYp7UOoRibdPRyAkcgPR18Y89GEf29TnD9vGfWWd4m+1iCYiaZmxwO1dJ6mabkdc99nkLfH8bH9HM+0v5ZanB91iA7mZcZ6GarcGh4AsY8K8eJEcZWehxk09GS3Q75J9kb7oVnQzquPhYa1DVs0bY/crYcltlgAJnCmlgWuBxYChu1cx2H4JdZFiIR1RpXW5D2NnCaLpueNp5FanFF1CXbgQpwMasGCVIWlmBx27x+wJPwOC4=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 sudo: required
 env:
-  - NODE=8
-  - NODE=8.11
-  - NODE=10
+  matrix:
+    - NODE=8
+    - NODE=8.11
+    - NODE=10
 services:
 - docker
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.9-alpine
+FROM node:8.11-alpine
 
 ENV HOME /root
 WORKDIR /root

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.11-alpine
+FROM node:{VERSION}-alpine
 
 ENV HOME /root
 WORKDIR /root

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # dockerbase-node
 
-Provides a base image to run node.js applications in.
+Provides a base image to run node.js applications in: `stocard/node:X.Y`
+
+You can try it out by: `docker run -it stocard/node:8.11 node`
 
 It currently builds three different base images:
 
@@ -8,7 +10,7 @@ It currently builds three different base images:
 * node version 8.x
 * node version 10.x
 
-It size is ~26MB.
+The size is ~26MB.
 
 ### More information
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,22 @@
 # dockerbase-node
 
-node version 8.11.x downloaded from
-https://nodejs.org/dist/
+Provides a base image to run node.js applications in.
 
+It currently builds three different base images:
 
-with tini-init from
-https://github.com/krallin/tini
+* newest minor semver of node 8
+* node version 8.x
+* node version 10.x
 
+It size is ~26MB.
+
+### More information
+
+The base image is based on `node:x.x-alpine` (https://hub.docker.com/_/node/).
+
+It also includes:
+
+* `bash`
+* `curl`
+
+and has tini-init from https://github.com/krallin/tini

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dockerbase-node
 
-node version 8.9.1 downloaded from
+node version 8.11.x downloaded from
 https://nodejs.org/dist/
 
 

--- a/README.md
+++ b/README.md
@@ -22,3 +22,8 @@ It also includes:
 * `curl`
 
 and has tini-init from https://github.com/krallin/tini
+
+### Adding new versions
+
+* Add a new `- env: NODE=<<MAJOR_OR_MINOR_VERSION>>` line to `matrix include` block. Don't forget to insert a version!
+* Also update the description above to add the new version.


### PR DESCRIPTION
This PR introduces a build matrix for our docker node base images.

Whenever a build is triggered (most probably through the travis cronjob), for all specified node version a docker image will be build and pushed to the docker registry.