### PR TITLE
Add node 16. Remove versions lower than 12

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -6,20 +6,20 @@ on:
       - master
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
-        NODE: [8, 8.11, 8.17, 10, 12, 14]
+        NODE: [12, 14, 16]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+
     - name: Insert node version into Dockerfile
       run: sed -i "s/{VERSION}/${{ matrix.NODE }}/g" ./Dockerfile
+    
     - name: Build the Docker image
       run: docker build -t stocard/node:${{ matrix.NODE }} .
+    
     - name: Push docker image to dockerhub
       run: docker login -u="${{ secrets.DOCKER_USERNAME }}" -p="${{ secrets.DOCKER_PASSWORD }}" && docker push stocard/node:${{ matrix.NODE }} && docker logout

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -3,18 +3,17 @@ name: Docker Image Build & Test
 on: [push]
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
-        NODE: [8, 8.11, 8.17, 10, 12, 14]
+        NODE: [12, 14, 16]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+
     - name: Insert node version into Dockerfile
       run: sed -i "s/{VERSION}/${{ matrix.NODE }}/g" ./Dockerfile
+    
     - name: Build the Docker image
       run: docker build -t stocard/node:${{ matrix.NODE }} .

--- a/README.md
+++ b/README.md
@@ -2,15 +2,12 @@
 
 Provides a base image to run node.js applications in: `stocard/node:X.Y`
 
-You can try it out by: `docker run -it stocard/node:8.11 node`
+You can try it out by: `docker run -it stocard/node:12 node`
 
-It currently builds three different base images:
-
-* newest minor semver of node 8
-* node version 8.x
-* node version 10.x
-
-The size is ~26MB.
+Current base images:
+- 12
+- 14
+- 16
 
 ### More information
 


### PR DESCRIPTION
Versions 10 and lower reached their end of life. THis is the current timeline

![node-releases](https://user-images.githubusercontent.com/4974020/148511495-c4e79015-3486-459d-a054-9dd54184a5d6.png)
