### PR TITLE
Scheduled image updates

### DIFF
--- a/.github/workflows/scheduled-update.yml
+++ b/.github/workflows/scheduled-update.yml
@@ -39,8 +39,14 @@ jobs:
 
         cat ./Dockerfile
     
-    # - name: Build the Docker image
-    #   run: docker build -t stocard/node:${{ matrix.NODE }} .
+    - name: Build the Docker image
+      run: docker build -t stocard/node:${LATEST_NODE_VERSION} .
     
-    # - name: Push docker image to dockerhub
-    #   run: docker login -u="${{ secrets.DOCKER_USERNAME }}" -p="${{ secrets.DOCKER_PASSWORD }}" && docker push stocard/node:${{ matrix.NODE }} && docker logout
+    - name: Push docker image to dockerhub
+      run: |
+        docker login -u="${{ secrets.DOCKER_USERNAME }}" -p="${{ secrets.DOCKER_PASSWORD }}"
+
+        echo "Pushing docker stocard/node:${LATEST_NODE_VERSION} to dockerhub"
+        docker push stocard/node:${LATEST_NODE_VERSION}
+        
+        docker logout

--- a/.github/workflows/scheduled-update.yml
+++ b/.github/workflows/scheduled-update.yml
@@ -1,0 +1,46 @@
+name: Scheduled Update
+
+# This event is triggered every Monday at 10:00 UTC
+on:
+  # schedule:
+  #   - cron: '0 10 * * MON' # https://crontab.guru/#0_10_*_*_MON
+  push:
+    branches:
+      - scheduled-image-updates
+
+jobs:
+  update:
+    name: Update Nodejs based docker image
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        NODE: [12, 14, 16]
+
+    steps:
+    - uses: actions/checkout@v2
+      name: Cloning repository
+
+    - uses: actions/setup-node@v2
+      name: Setting Node.js Version
+      with:
+        node-version: '${{ matrix.NODE }}.x'
+
+    - name: Determine latest version for v${{ matrix.NODE }}
+      run: |
+        LATEST_NODE_VERSION=$(node --version | sed -r "s/[v]//g")
+
+        echo "Latest version is ${LATEST_NODE_VERSION}"
+
+        echo "LATEST_NODE_VERSION=${LATEST_NODE_VERSION}" >> $GITHUB_ENV 
+
+    - name: Insert node version into Dockerfile
+      run: |
+        sed -i "s/{VERSION}/${LATEST_NODE_VERSION}/g" ./Dockerfile
+
+        cat ./Dockerfile
+    
+    # - name: Build the Docker image
+    #   run: docker build -t stocard/node:${{ matrix.NODE }} .
+    
+    # - name: Push docker image to dockerhub
+    #   run: docker login -u="${{ secrets.DOCKER_USERNAME }}" -p="${{ secrets.DOCKER_PASSWORD }}" && docker push stocard/node:${{ matrix.NODE }} && docker logout

--- a/.github/workflows/scheduled-update.yml
+++ b/.github/workflows/scheduled-update.yml
@@ -38,15 +38,21 @@ jobs:
         sed -i "s/{VERSION}/${LATEST_NODE_VERSION}/g" ./Dockerfile
 
         cat ./Dockerfile
-    
-    - name: Build the Docker image
+
+    - name: Build & Tag docker image for ${{ env.LATEST_NODE_VERSION }}
       run: docker build -t stocard/node:${LATEST_NODE_VERSION} .
     
-    - name: Push docker image to dockerhub
+    - name: Push docker image ${{ env.LATEST_NODE_VERSION }} to dockerhub
       run: |
-        docker login -u="${{ secrets.DOCKER_USERNAME }}" -p="${{ secrets.DOCKER_PASSWORD }}"
-
         echo "Pushing docker stocard/node:${LATEST_NODE_VERSION} to dockerhub"
         docker push stocard/node:${LATEST_NODE_VERSION}
-        
-        docker logout
+
+    - name: Tag & Push docker image ${{ matrix.NODE }} to dockerhub
+      run: |
+        docker tag stocard/node:${LATEST_NODE_VERSION} stocard/node:${{ matrix.NODE }}
+
+        echo "Pushing docker stocard/node:${{ matrix.NODE }} to dockerhub"
+        docker push stocard/node:${{ matrix.NODE }}
+
+    - name: Logout of dockerhub
+      run: docker logout

--- a/.github/workflows/scheduled-update.yml
+++ b/.github/workflows/scheduled-update.yml
@@ -2,12 +2,9 @@ name: Scheduled Update
 
 # This event is triggered every Monday at 10:00 UTC
 on:
-  # schedule:
-  #   - cron: '0 10 * * MON' # https://crontab.guru/#0_10_*_*_MON
-  push:
-    branches:
-      - scheduled-image-updates
-
+  schedule:
+    - cron: '0 10 * * MON' # https://crontab.guru/#0_10_*_*_MON
+  
 jobs:
   update:
     name: Update Nodejs based docker image

--- a/.github/workflows/scheduled-update.yml
+++ b/.github/workflows/scheduled-update.yml
@@ -34,8 +34,6 @@ jobs:
       run: |
         sed -i "s/{VERSION}/${LATEST_NODE_VERSION}/g" ./Dockerfile
 
-        cat ./Dockerfile
-
     - name: Login to dockerhub
       run: docker login -u="${{ secrets.DOCKER_USERNAME }}" -p="${{ secrets.DOCKER_PASSWORD }}"
 

--- a/.github/workflows/scheduled-update.yml
+++ b/.github/workflows/scheduled-update.yml
@@ -39,6 +39,9 @@ jobs:
 
         cat ./Dockerfile
 
+    - name: Login to dockerhub
+      run: docker login -u="${{ secrets.DOCKER_USERNAME }}" -p="${{ secrets.DOCKER_PASSWORD }}"
+
     - name: Build & Tag docker image for ${{ env.LATEST_NODE_VERSION }}
       run: docker build -t stocard/node:${LATEST_NODE_VERSION} .
     


### PR DESCRIPTION
This PR introduces a scheduled CI that will:
- Run every **_Monday at 10:00 UTC_**
- Determine the latest NodeJS version for every version specified in the job matrix
- Build, Tag & Push an open version docker image. e.g: `stocard/node:14`
- Build, Tag & Push a lock version docker image. e.g: `stocard/node:14.18.2`

Both images contain the latest version at the moment of the run, but the locked version will let you stay on a specific NodeJS version in case you need it, for whatever reason (security issues, code-breaking updates, etc)

See [Stocard Dockerhub](https://hub.docker.com/r/stocard/node/tags)